### PR TITLE
Remove touch "flash" and make it work more like a UIButton 

### DIFF
--- a/LGButton/Classes/LGButton.swift
+++ b/LGButton/Classes/LGButton.swift
@@ -8,34 +8,22 @@
 import UIKit
 import QuartzCore
 
-let untouchedAlpha : CGFloat = 1.0
-let touchedAlpha :CGFloat = 0.7
-let touchDisableRadius : CGFloat = 100.0
 
 @IBDesignable
 public class LGButton: UIControl {
     
+    enum TouchAlphaValues : CGFloat
+    {
+        case touched = 0.7
+        case untouched = 1.0
+    }
+
+    let touchDisableRadius : CGFloat = 100.0
+
     let availableFontIcons = ["fa", "io", "oc", "ic", "ma", "ti", "mi"]
     
     var gradient : CAGradientLayer?
-    var touchAlpha : CGFloat = untouchedAlpha
-    {
-        didSet {
-            updateTouchAlpha()
-        }
-    }
     
-    var pressed : Bool = false
-    {
-        didSet {
-            if !showTouchFeedback
-            {
-                return
-            }
-
-            touchAlpha = (pressed) ? touchedAlpha : untouchedAlpha
-        }
-    }
     
     fileprivate var rootView : UIView!
     @IBOutlet fileprivate weak var titleLbl: UILabel!
@@ -611,50 +599,56 @@ public class LGButton: UIControl {
     
     // MARK: - Touches
     // MARK:
-    override public func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?)
-    {
+    var touchAlpha : TouchAlphaValues = .untouched {
+        didSet {
+            updateTouchAlpha()
+        }
+    }
+    
+    var pressed : Bool = false {
+        didSet {
+            if !showTouchFeedback {
+                return
+            }
+            
+            touchAlpha = (pressed) ? .touched : .untouched
+        }
+    }
+
+    override public func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?){
         pressed = true
     }
     
-    override public func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?)
-    {
+    override public func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?){
         let shouldSendActions = pressed
         pressed = false
-        if shouldSendActions
-        {
+        if shouldSendActions{
             sendActions(for: .touchUpInside)
         }
     }
     
-    override public func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?)
-    {
-        if let touchLoc = touches.first?.location(in: self)
-        {
+    override public func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?){
+        if let touchLoc = touches.first?.location(in: self){
             if (touchLoc.x < -touchDisableRadius ||
                 touchLoc.y < -touchDisableRadius ||
                 touchLoc.x > self.bounds.size.width + touchDisableRadius ||
-                touchLoc.y > self.bounds.size.height + touchDisableRadius)
-            {
+                touchLoc.y > self.bounds.size.height + touchDisableRadius){
                 pressed = false
             }
-            else if self.touchAlpha == 1.0
-            {
+            else if self.touchAlpha == .untouched {
                 pressed = true
             }
         }
     }
     
-    override public func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?)
-    {
+    override public func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
         pressed = false
     }
     
-    func updateTouchAlpha()
-    {
-        if self.alpha != self.touchAlpha
-        {
+    func updateTouchAlpha() {
+        if self.alpha != self.touchAlpha.rawValue {
             UIView.animate(withDuration: 0.3) {
-                self.alpha = self.touchAlpha
+                self.alpha = self.touchAlpha.rawValue
             }
         }
     }

--- a/LGButton/Classes/LGButton.swift
+++ b/LGButton/Classes/LGButton.swift
@@ -12,8 +12,7 @@ import QuartzCore
 @IBDesignable
 public class LGButton: UIControl {
     
-    enum TouchAlphaValues : CGFloat
-    {
+    enum TouchAlphaValues : CGFloat {
         case touched = 0.7
         case untouched = 1.0
     }

--- a/LGButton/Classes/LGButton.swift
+++ b/LGButton/Classes/LGButton.swift
@@ -8,13 +8,35 @@
 import UIKit
 import QuartzCore
 
+let untouchedAlpha : CGFloat = 1.0
+let touchedAlpha :CGFloat = 0.7
+let touchDisableRadius : CGFloat = 100.0
+
 @IBDesignable
 public class LGButton: UIControl {
     
     let availableFontIcons = ["fa", "io", "oc", "ic", "ma", "ti", "mi"]
     
     var gradient : CAGradientLayer?
+    var touchAlpha : CGFloat = untouchedAlpha
+    {
+        didSet {
+            updateTouchAlpha()
+        }
+    }
+    
+    var pressed : Bool = false
+    {
+        didSet {
+            if !showTouchFeedback
+            {
+                return
+            }
 
+            touchAlpha = (pressed) ? touchedAlpha : untouchedAlpha
+        }
+    }
+    
     fileprivate var rootView : UIView!
     @IBOutlet fileprivate weak var titleLbl: UILabel!
     @IBOutlet fileprivate weak var mainStackView: UIStackView!
@@ -589,16 +611,51 @@ public class LGButton: UIControl {
     
     // MARK: - Touches
     // MARK:
-    override public func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        if showTouchFeedback {
-            alpha = 0.7
-            UIView.animate(withDuration: 0.3) {
-                self.alpha = 1
+    override public func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?)
+    {
+        pressed = true
+    }
+    
+    override public func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?)
+    {
+        let shouldSendActions = pressed
+        pressed = false
+        if shouldSendActions
+        {
+            sendActions(for: .touchUpInside)
+        }
+    }
+    
+    override public func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?)
+    {
+        if let touchLoc = touches.first?.location(in: self)
+        {
+            if (touchLoc.x < -touchDisableRadius ||
+                touchLoc.y < -touchDisableRadius ||
+                touchLoc.x > self.bounds.size.width + touchDisableRadius ||
+                touchLoc.y > self.bounds.size.height + touchDisableRadius)
+            {
+                pressed = false
+            }
+            else if self.touchAlpha == 1.0
+            {
+                pressed = true
             }
         }
     }
     
-    override public func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-        sendActions(for: .touchUpInside)
+    override public func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?)
+    {
+        pressed = false
+    }
+    
+    func updateTouchAlpha()
+    {
+        if self.alpha != self.touchAlpha
+        {
+            UIView.animate(withDuration: 0.3) {
+                self.alpha = self.touchAlpha
+            }
+        }
     }
 }


### PR DESCRIPTION
These changes make the button behave more like a standard UIButton in two ways:

1) rather than "flashing" the button when touched the "highlight" remains as long as the touch is held
2) exception to #1 is if the touch is moved too far away, the highlight is removed and the touch up action will not be taken.  If the touch is moved back closer, the highlight will be put back and the action will occur at touch up.

In the example app you should disable scrolling to try this as the scrolling takes precedence if the touch is moved.
