### PR TITLE
Bug Fix: rootView added twice, AutoLayout warnings

### DIFF
--- a/LGButton/Classes/LGButton.swift
+++ b/LGButton/Classes/LGButton.swift
@@ -631,6 +631,7 @@ public class LGButton: UIControl {
     // MARK: - Xib file
     // MARK:
     fileprivate func xibSetup() {
+		guard rootView == nil else { return }
         rootView = loadViewFromNib()
         rootView.frame = bounds
         rootView.autoresizingMask = [.flexibleWidth, .flexibleHeight]

--- a/LGButton/Resources/LGButton.xib
+++ b/LGButton/Resources/LGButton.xib
@@ -106,7 +106,7 @@
                 <constraint firstItem="WKx-U5-Fez" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="mhQ-mz-r48"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="WKx-U5-Fez" secondAttribute="trailing" constant="32" id="pRy-28-jvf"/>
                 <constraint firstItem="Olz-81-yKk" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="s8C-be-AUi"/>
-                <constraint firstItem="HQ2-LV-9mO" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="sYg-6j-37c"/>
+                <constraint firstItem="HQ2-LV-9mO" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" priority="999" id="sYg-6j-37c"/>
                 <constraint firstItem="WKx-U5-Fez" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" priority="750" id="vVH-rZ-Bhm"/>
                 <constraint firstItem="HQ2-LV-9mO" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="xxj-9X-oxK"/>
                 <constraint firstItem="WKx-U5-Fez" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iN0-l3-epB" secondAttribute="leading" constant="32" id="zf0-aD-IWu"/>
@@ -116,7 +116,7 @@
             <connections>
                 <outletCollection property="gestureRecognizers" destination="VEO-YD-W6I" appends="YES" id="7OI-gI-vZd"/>
             </connections>
-            <point key="canvasLocation" x="-26.5" y="-218.5"/>
+            <point key="canvasLocation" x="-27.199999999999999" y="-218.59070464767618"/>
         </view>
         <tapGestureRecognizer id="VEO-YD-W6I">
             <connections>

--- a/LGButton/Resources/LGButton.xib
+++ b/LGButton/Resources/LGButton.xib
@@ -4,7 +4,6 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -47,8 +46,8 @@
                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="nM5-1x-KcY">
                             <rect key="frame" x="0.0" y="28.5" width="20" height="20"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="20" id="cXM-PQ-bte"/>
-                                <constraint firstAttribute="width" constant="20" id="e53-Mt-tx6"/>
+                                <constraint firstAttribute="height" priority="999" constant="20" id="cXM-PQ-bte"/>
+                                <constraint firstAttribute="width" priority="999" constant="20" id="e53-Mt-tx6"/>
                             </constraints>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="--" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yPu-j1-amS">
@@ -72,8 +71,8 @@
                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="9eI-ND-Xxs">
                             <rect key="frame" x="203" y="28.5" width="20" height="20"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="20" id="NGP-D9-laU"/>
-                                <constraint firstAttribute="width" constant="20" id="Y1b-dI-Wf2"/>
+                                <constraint firstAttribute="height" priority="999" constant="20" id="NGP-D9-laU"/>
+                                <constraint firstAttribute="width" priority="999" constant="20" id="Y1b-dI-Wf2"/>
                             </constraints>
                         </imageView>
                     </subviews>


### PR DESCRIPTION
This commit fixes 2 bugs, loregr#51 and loregr#52 (maybe more, loregr#50 is probably related):

- The rootView was added twice to the view hierarchy (xibSetup was somehow called twice, first from init and from awakeFromNib)
- A lot of AutoLayout errors are introduced to a view hierarchy when adding an LGButton (even in a setup with only one single LGButton as child). These are caused by Left and Right Image's size and Main Stackview's position X constraints being too "rigid" (Priorities were 1000, lowered to 999)

NB: "Clean Build Folder" for change to take effect